### PR TITLE
Use exec form for Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN chmod +x /app/speedtest
 WORKDIR /app
 USER app
 
-CMD /app/serve.py
+CMD ["/app/serve.py"]


### PR DESCRIPTION
The shell form prevents signals from propagating to the app.